### PR TITLE
fix cannot parse

### DIFF
--- a/lib/nginx/nginx.go
+++ b/lib/nginx/nginx.go
@@ -12,7 +12,7 @@ import (
 	ltsv "github.com/Songmu/go-ltsv"
 )
 
-const timeFormat = "02/Jan/2006:15:04:05 +0900"
+const timeFormat = "02/Jan/2006:15:04:05 -0700"
 
 type logTime struct {
 	time.Time


### PR DESCRIPTION
fix 
```
panic: field "Time": parsing time "10/Jul/2022:05:05:16 +0000" as "02/Jan/2006:15:04:05 +0900": cannot parse "000" as " +0900"
```