### PR TITLE
Update module path to v2 and adjust imports accordingly

### DIFF
--- a/cmd/chartjs.go
+++ b/cmd/chartjs.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aokabi/ngraphinx/lib"
-	chartjs "github.com/aokabi/ngraphinx/lib/chatjs"
+	"github.com/aokabi/ngraphinx/v2/lib"
+	chartjs "github.com/aokabi/ngraphinx/v2/lib/chatjs"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aokabi/ngraphinx/lib"
-	graph "github.com/aokabi/ngraphinx/lib/graph"
+	"github.com/aokabi/ngraphinx/v2/lib"
+	graph "github.com/aokabi/ngraphinx/v2/lib/graph"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	graph "github.com/aokabi/ngraphinx/lib/graph"
+	graph "github.com/aokabi/ngraphinx/v2/lib/graph"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aokabi/ngraphinx
+module github.com/aokabi/ngraphinx/v2
 
 go 1.23
 

--- a/lib/chatjs/graph.go
+++ b/lib/chatjs/graph.go
@@ -10,8 +10,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/aokabi/ngraphinx/lib"
-	"github.com/aokabi/ngraphinx/lib/nginx"
+	"github.com/aokabi/ngraphinx/v2/lib"
+	"github.com/aokabi/ngraphinx/v2/lib/nginx"
 	"gonum.org/v1/plot/plotutil"
 )
 

--- a/lib/graph/graph.go
+++ b/lib/graph/graph.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"time"
 
-	"github.com/aokabi/ngraphinx/lib"
-	"github.com/aokabi/ngraphinx/lib/nginx"
+	"github.com/aokabi/ngraphinx/v2/lib"
+	"github.com/aokabi/ngraphinx/v2/lib/nginx"
 	"gonum.org/v1/plot/plotutil"
 
 	"gonum.org/v1/plot"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/aokabi/ngraphinx/cmd"
+	"github.com/aokabi/ngraphinx/v2/cmd"
 )
 
 func main() {


### PR DESCRIPTION
This pull request includes several changes to update the import paths in the project to use the new version `v2` of the `ngraphinx` module. This affects multiple files across the codebase.

The most important changes include:

Module version update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1): Updated the module path to `github.com/aokabi/ngraphinx/v2` to reflect the new version.