### PR TITLE
Update installation command in README to reflect module path change

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ nginxのaccess.logを時系列のグラフにするcliツール
 ![](./docs/sample.png)
 
 ## install
-`go install github.com/aokabi/ngraphinx@latest`
+`go install github.com/aokabi/ngraphinx/v2@latest`
 
 ## usage
 ### image


### PR DESCRIPTION
This pull request includes a small but important change to the `README.md` file of the `nginxのaccess.logを時系列のグラフにするcliツール` project. The change updates the installation command to use the latest version of the package.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R8): Updated the installation command to `go install github.com/aokabi/ngraphinx/v2@latest` to ensure users install the latest version of the package.