### PR TITLE
Add output file path flag to chartjs and image commands

### DIFF
--- a/cmd/chartjs.go
+++ b/cmd/chartjs.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/aokabi/ngraphinx/v2/lib"
 	chartjs "github.com/aokabi/ngraphinx/v2/lib/chatjs"
@@ -11,6 +13,7 @@ import (
 
 var (
 	maxDatasetNum int
+	outputFilePath         string
 )
 
 func init() {
@@ -18,6 +21,7 @@ func init() {
 
 	// define flags
 	chartjsCmd.PersistentFlags().IntVar(&maxDatasetNum, "maxdataset", 10, "max dataset num")
+	chartjsCmd.PersistentFlags().StringVarP(&outputFilePath, "output", "o", fmt.Sprintf("%s.html", time.Now().Format(time.RFC3339)), "output file path")
 }
 
 var chartjsCmd = &cobra.Command{
@@ -32,7 +36,7 @@ var chartjsCmd = &cobra.Command{
 			regexps[i] = regexp.MustCompile(aggregate)
 		}
 
-		option := chartjs.NewOption(maxDatasetNum)
+		option := chartjs.NewOption(maxDatasetNum, outputFilePath)
 
 		return chartjs.GenerateGraph(regexps, nginxAccessLogFilepath, option)
 	},

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/aokabi/ngraphinx/v2/lib"
 	graph "github.com/aokabi/ngraphinx/v2/lib/graph"
@@ -11,6 +13,9 @@ import (
 
 func init() {
 	rootCmd.AddCommand(imageCmd)
+
+	// define flags
+	imageCmd.PersistentFlags().StringVarP(&outputFilePath, "output", "o", fmt.Sprintf("%s.png", time.Now().Format(time.RFC3339)), "output file path")
 }
 
 var imageCmd = &cobra.Command{
@@ -19,7 +24,7 @@ var imageCmd = &cobra.Command{
 	Long:  `Image commands`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		regStrs := strings.Split(aggregates, ",")
-		option := graph.NewOption(imageWidth, imageHeight, reqMinCountPerSec)
+		option := graph.NewOption(imageWidth, imageHeight, reqMinCountPerSec, outputFilePath)
 
 		regexps := make(lib.Regexps, len(regStrs))
 

--- a/lib/chatjs/graph.go
+++ b/lib/chatjs/graph.go
@@ -17,11 +17,13 @@ import (
 
 type Option struct {
 	maxDatasetNum int
+	outputFilePath string
 }
 
-func NewOption(maxDatasetNum int) *Option {
+func NewOption(maxDatasetNum int, outputFilePath string) *Option {
 	return &Option{
 		maxDatasetNum: maxDatasetNum,
+		outputFilePath: outputFilePath,
 	}
 }
 
@@ -55,7 +57,7 @@ func GenerateGraph(regexps lib.Regexps, logFilePath string, option *Option) erro
 	}
 
 	// ここでHTMLを出力する
-	file, err := os.Create(fmt.Sprintf("%s.html", time.Now().Format(time.RFC3339)))
+	file, err := os.Create(option.outputFilePath)
 	if err != nil {
 		return err
 	}

--- a/lib/graph/graph.go
+++ b/lib/graph/graph.go
@@ -28,13 +28,15 @@ type Option struct {
 	imageWidth  font.Length
 	imageHeight font.Length
 	minCount    int
+	outputFilePath string
 }
 
-func NewOption(w, h Inch, minCount int) *Option {
+func NewOption(w, h Inch, minCount int, outputFilePath string) *Option {
 	return &Option{
 		imageWidth:  font.Length(w),
 		imageHeight: font.Length(h),
 		minCount:    minCount,
+		outputFilePath: outputFilePath,
 	}
 }
 
@@ -245,7 +247,7 @@ func GenerateGraph(aggregates lib.Regexps, nginxAccessLogFilepath string, option
 		}
 	}
 
-	w, err := os.Create(fmt.Sprintf("%s.png", time.Now().Format(time.RFC3339)))
+	w, err := os.Create(option.outputFilePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request includes changes to add an `outputFilePath` parameter to the `Option` struct and update related functions to use this new parameter for specifying output file paths. The changes span multiple files and involve modifying the `cmd/chartjs.go`, `cmd/image.go`, `lib/chatjs/graph.go`, and `lib/graph/graph.go` files.

### Enhancements to Output File Path Handling:

* [`cmd/chartjs.go`](diffhunk://#diff-b60484c6f11c52439709446803d43f57aaf8e9b79c2469d4b6e01010865f393cR16-R24): Added `outputFilePath` flag and updated the `chartjsCmd` command to use the new `outputFilePath` parameter in the `Option` struct. [[1]](diffhunk://#diff-b60484c6f11c52439709446803d43f57aaf8e9b79c2469d4b6e01010865f393cR16-R24) [[2]](diffhunk://#diff-b60484c6f11c52439709446803d43f57aaf8e9b79c2469d4b6e01010865f393cL35-R39)
* [`cmd/image.go`](diffhunk://#diff-65ae6b7ae51d8781e426f305c8043d4fd9c30eca9e2de643217efed0e557adb2R16-R18): Added `outputFilePath` flag and updated the `imageCmd` command to use the new `outputFilePath` parameter in the `Option` struct. [[1]](diffhunk://#diff-65ae6b7ae51d8781e426f305c8043d4fd9c30eca9e2de643217efed0e557adb2R16-R18) [[2]](diffhunk://#diff-65ae6b7ae51d8781e426f305c8043d4fd9c30eca9e2de643217efed0e557adb2L22-R27)
