### PR TITLE
move root to image command flags for width, height, and minimum reque…

### DIFF
--- a/cmd/image.go
+++ b/cmd/image.go
@@ -11,11 +11,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	imageWidth             graph.Inch
+	imageHeight            graph.Inch
+	reqMinCountPerSec      int
+)
+
 func init() {
 	rootCmd.AddCommand(imageCmd)
 
 	// define flags
 	imageCmd.PersistentFlags().StringVarP(&outputFilePath, "output", "o", fmt.Sprintf("%s.png", time.Now().Format(time.RFC3339)), "output file path")
+	imageCmd.PersistentFlags().IntVar(&imageWidth, "width", 10, "image width(Inch)")
+	imageCmd.PersistentFlags().IntVar(&imageHeight, "height", 10, "image height(Inch)")
+	imageCmd.PersistentFlags().IntVar(&reqMinCountPerSec, "mincount", 20, "required min request count per sec")
 }
 
 var imageCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	graph "github.com/aokabi/ngraphinx/v2/lib/graph"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -18,9 +17,6 @@ var (
 
 	nginxAccessLogFilepath string
 	aggregates             string
-	imageWidth             graph.Inch
-	imageHeight            graph.Inch
-	reqMinCountPerSec      int
 )
 
 func Execute() error {
@@ -33,8 +29,5 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&userLicense, "license", "l", "", "name of license for the project")
 	rootCmd.PersistentFlags().StringVar(&aggregates, "aggregates", "", "aggregate endpoint")
 	rootCmd.PersistentFlags().StringVar(&nginxAccessLogFilepath, "path", "access.log", "nginx access log path")
-	rootCmd.PersistentFlags().IntVar(&imageWidth, "width", 10, "image width(Inch)")
-	rootCmd.PersistentFlags().IntVar(&imageHeight, "height", 10, "image height(Inch)")
-	rootCmd.PersistentFlags().IntVar(&reqMinCountPerSec, "mincount", 20, "required min request count per sec")
 	viper.SetDefault("license", "apache")
 }


### PR DESCRIPTION
This pull request includes changes to the `cmd` package, specifically to the `image.go` and `root.go` files, to refactor the handling of certain flags. The most important changes include moving the image-related flags from `root.go` to `image.go`.

### Refactoring of flag handling:

* [`cmd/image.go`](diffhunk://#diff-65ae6b7ae51d8781e426f305c8043d4fd9c30eca9e2de643217efed0e557adb2R14-R27): Added new flags for `imageWidth`, `imageHeight`, and `reqMinCountPerSec` to the `imageCmd` command.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL4): Removed the flags for `imageWidth`, `imageHeight`, and `reqMinCountPerSec` from the `rootCmd` command.