### PR TITLE
bump version to 2.0.2 in root command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ var (
 		Use:   "ngraphinx",
 		Short: "ngraphinx is a tool to generate graph from nginx access log",
 		Long:  "ngraphinx is a tool to generate graph from nginx access log",
+		Version: "2.0.2",
 	}
 
 	nginxAccessLogFilepath string


### PR DESCRIPTION
This pull request includes a small change to the `cmd/root.go` file. The change adds a version number to the `var` block.

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR16): Added `Version: "2.0.2"` to the `var` block to specify the version of the tool.